### PR TITLE
fix: broken youtube link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 <p align="left">
 <a href="https://dev.to/bashamega" target="blank"><img align="center" src="https://raw.githubusercontent.com/rahuldkjain/github-profile-readme-generator/master/src/images/icons/Social/devto.svg" alt="bashamega" height="30" width="40" /></a>
 <a href="https://stackoverflow.com/users/20731770" target="blank"><img align="center" src="https://raw.githubusercontent.com/rahuldkjain/github-profile-readme-generator/master/src/images/icons/Social/stack-overflow.svg" alt="20731770" height="30" width="40" /></a>
-<a href="https://www.youtube.com/c/bashacoder" target="blank"><img align="center" src="https://raw.githubusercontent.com/rahuldkjain/github-profile-readme-generator/master/src/images/icons/Social/youtube.svg" alt="bashacoder" height="30" width="40" /></a>
+<a href="https://www.youtube.com/@bashacoder" target="blank"><img align="center" src="https://raw.githubusercontent.com/rahuldkjain/github-profile-readme-generator/master/src/images/icons/Social/youtube.svg" alt="bashacoder" height="30" width="40" /></a>
 </p>
 
 <h3 align="left">Languages and Tools:</h3>


### PR DESCRIPTION
You current link on the youtube image links to a 404 page. I updated the link so it correctly links back to your channel